### PR TITLE
fix plugin config

### DIFF
--- a/google-cloud-bigquerystorage/pom.xml
+++ b/google-cloud-bigquerystorage/pom.xml
@@ -26,9 +26,12 @@
     </extensions>
     <plugins>
       <plugin>
-        <groupId>com.google.protobuf.tools</groupId>
-        <artifactId>maven-protoc-plugin</artifactId>
-        <version>0.4.2</version>
+<!--        <groupId>com.google.protobuf.tools</groupId>-->
+<!--        <artifactId>maven-protoc-plugin</artifactId>-->
+<!--        <version>0.4.2</version>-->
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>0.6.1</version>
         <configuration>
           <protocArtifact>com.google.protobuf:protoc:${project.protobuf-java.version}:exe:${os.detected.classifier}</protocArtifact>
         </configuration>
@@ -39,16 +42,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>com.google.api.client.http.protobuf</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
       </plugin>
     </plugins>
   </build>
@@ -192,10 +185,6 @@
       <groupId>com.google.zetasql</groupId>
       <artifactId>zetasql-types</artifactId>
       <version>2020.02.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
     </dependency>
   </dependencies>
 

--- a/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/ProtoSchemaConverterTest.java
+++ b/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1alpha2/ProtoSchemaConverterTest.java
@@ -18,11 +18,12 @@ package com.google.cloud.bigquery.storage.v1alpha2;
 import org.junit.*;
 
 import java.io.IOException;
-import com.google.cloud.bigquery.storage.test.AllSupportedTypes;
+import com.google.cloud.bigquery.storage.test.Test.AllSupportedTypes;
 
 public class ProtoSchemaConverterTest {
 	@Before
 	public void setUp() throws IOException {
+		AllSupportedTypes.getDefaultInstance();
 	}
 
 	@Test


### PR DESCRIPTION
The `maven-jar-plugin` config was unnecessary and we probably want to switch to the `xolstice` plugin.